### PR TITLE
Fix concurrency issues

### DIFF
--- a/Http.jl
+++ b/Http.jl
@@ -91,9 +91,8 @@ module Http
     immutable Client
         id::Int
         sock::TcpSocket
-        attr::Dict
 
-        Client(id::Int,sock::TcpSocket) = new(id,sock,{ "keepAlive" => false })
+        Client(id::Int,sock::TcpSocket) = new(id, sock)
     end
 
     # Request / Response
@@ -166,9 +165,6 @@ module Http
             end
             event( "write", server, client, response )
             write( client.sock, render(response) )               # Send the response
-            if client.attr["keepAlive"]
-                return true
-            end
             event( "close", server, client )
             close( client.sock )                                 # Close this connection
             false                                                # Return false to prevent an error at stream.jl:190

--- a/Http.jl
+++ b/Http.jl
@@ -184,14 +184,14 @@ end
 # Listen on $port, accept client connections
 
 function run( server::Server, port::Integer )
-    idPool = 0                                               # Increments for each connection
+    id_pool = 0                                               # Increments for each connection
     sock = server.http.sock
     websockets_enabled = server.websock != nothing
     uv_error("listen", !bind(sock, Base.IPv4(uint32(0)), uint16(port)) )
     listen( sock )
     event( "listen", server, port )
     while true # handle requests, Base.wait_accept blocks until a connection is made
-        client = Client( idPool += 1, Base.wait_accept(sock) )
+        client = Client( id_pool += 1, Base.wait_accept(sock) )
         client.parser = RequestParser.ClientParser( message_handler(server, client, websockets_enabled) )
         process_client( server, client, websockets_enabled )
     end

--- a/Http.jl
+++ b/Http.jl
@@ -1,190 +1,191 @@
 module Http
 
-    using RequestParser
-    export Server, HttpHandler, WebsocketHandler, Request, Response, run
+using RequestParser
+export Server, HttpHandler, WebsocketHandler, Request, Response, run
 
-    STATUS_CODES = {
-      100 => "Continue",
-      101 => "Switching Protocols",
-      102 => "Processing",                          # RFC 2518, obsoleted by RFC 4918
-      200 => "OK",
-      201 => "Created",
-      202 => "Accepted",
-      203 => "Non-Authoritative Information",
-      204 => "No Content",
-      205 => "Reset Content",
-      206 => "Partial Content",
-      207 => "Multi-Status",                        # RFC 4918
-      300 => "Multiple Choices",
-      301 => "Moved Permanently",
-      302 => "Moved Temporarily",
-      303 => "See Other",
-      304 => "Not Modified",
-      305 => "Use Proxy",
-      307 => "Temporary Redirect",
-      400 => "Bad Request",
-      401 => "Unauthorized",
-      402 => "Payment Required",
-      403 => "Forbidden",
-      404 => "Not Found",
-      405 => "Method Not Allowed",
-      406 => "Not Acceptable",
-      407 => "Proxy Authentication Required",
-      408 => "Request Time-out",
-      409 => "Conflict",
-      410 => "Gone",
-      411 => "Length Required",
-      412 => "Precondition Failed",
-      413 => "Request Entity Too Large",
-      414 => "Request-URI Too Large",
-      415 => "Unsupported Media Type",
-      416 => "Requested Range Not Satisfiable",
-      417 => "Expectation Failed",
-      418 => "I'm a teapot",                        # RFC 2324
-      422 => "Unprocessable Entity",                # RFC 4918
-      423 => "Locked",                              # RFC 4918
-      424 => "Failed Dependency",                   # RFC 4918
-      425 => "Unordered Collection",                # RFC 4918
-      426 => "Upgrade Required",                    # RFC 2817
-      428 => "Precondition Required",               # RFC 6585
-      429 => "Too Many Requests",                   # RFC 6585
-      431 => "Request Header Fields Too Large",     # RFC 6585
-      500 => "Internal Server Error",
-      501 => "Not Implemented",
-      502 => "Bad Gateway",
-      503 => "Service Unavailable",
-      504 => "Gateway Time-out",
-      505 => "HTTP Version Not Supported",
-      506 => "Variant Also Negotiates",             # RFC 2295
-      507 => "Insufficient Storage",                # RFC 4918
-      509 => "Bandwidth Limit Exceeded",
-      510 => "Not Extended",                        # RFC 2774
-      511 => "Network Authentication Required"      # RFC 6585
-    };
+STATUS_CODES = {
+    100 => "Continue",
+    101 => "Switching Protocols",
+    102 => "Processing",                          # RFC 2518, obsoleted by RFC 4918
+    200 => "OK",
+    201 => "Created",
+    202 => "Accepted",
+    203 => "Non-Authoritative Information",
+    204 => "No Content",
+    205 => "Reset Content",
+    206 => "Partial Content",
+    207 => "Multi-Status",                        # RFC 4918
+    300 => "Multiple Choices",
+    301 => "Moved Permanently",
+    302 => "Moved Temporarily",
+    303 => "See Other",
+    304 => "Not Modified",
+    305 => "Use Proxy",
+    307 => "Temporary Redirect",
+    400 => "Bad Request",
+    401 => "Unauthorized",
+    402 => "Payment Required",
+    403 => "Forbidden",
+    404 => "Not Found",
+    405 => "Method Not Allowed",
+    406 => "Not Acceptable",
+    407 => "Proxy Authentication Required",
+    408 => "Request Time-out",
+    409 => "Conflict",
+    410 => "Gone",
+    411 => "Length Required",
+    412 => "Precondition Failed",
+    413 => "Request Entity Too Large",
+    414 => "Request-URI Too Large",
+    415 => "Unsupported Media Type",
+    416 => "Requested Range Not Satisfiable",
+    417 => "Expectation Failed",
+    418 => "I'm a teapot",                        # RFC 2324
+    422 => "Unprocessable Entity",                # RFC 4918
+    423 => "Locked",                              # RFC 4918
+    424 => "Failed Dependency",                   # RFC 4918
+    425 => "Unordered Collection",                # RFC 4918
+    426 => "Upgrade Required",                    # RFC 2817
+    428 => "Precondition Required",               # RFC 6585
+    429 => "Too Many Requests",                   # RFC 6585
+    431 => "Request Header Fields Too Large",     # RFC 6585
+    500 => "Internal Server Error",
+    501 => "Not Implemented",
+    502 => "Bad Gateway",
+    503 => "Service Unavailable",
+    504 => "Gateway Time-out",
+    505 => "HTTP Version Not Supported",
+    506 => "Variant Also Negotiates",             # RFC 2295
+    507 => "Insufficient Storage",                # RFC 4918
+    509 => "Bandwidth Limit Exceeded",
+    510 => "Not Extended",                        # RFC 2774
+    511 => "Network Authentication Required"      # RFC 6585
+}
 
-    # Request handlers
+# Request handlers
 
-    immutable HttpHandler
-        handle::Function
-        sock::TcpSocket
-        events::Dict
+immutable HttpHandler
+    handle::Function
+    sock::TcpSocket
+    events::Dict
 
-        HttpHandler(handle::Function) = new( handle, TcpSocket(), (ASCIIString=>Function)[] )
+    HttpHandler(handle::Function) = new( handle, TcpSocket(), (ASCIIString=>Function)[] )
+end
+
+immutable WebsocketHandler
+    handle::Function            # ( sock ) -> ...
+end
+
+# Server / Client
+
+immutable Server
+    http::HttpHandler
+    websock::Union(Nothing,WebsocketHandler)
+end
+
+Server(http::HttpHandler)                        = Server( http, nothing )
+Server(handler::Function)                        = Server( HttpHandler(handler) )
+Server(websock::WebsocketHandler)                = Server( HttpHandler( req -> Response(404) ), websock )
+Server(handler::Function, sockhandler::Function) = Server( HttpHandler(handler), WebsocketHandler(sockhandler) )
+
+immutable Client
+    id::Int
+    sock::TcpSocket
+
+    Client(id::Int,sock::TcpSocket) = new(id, sock)
+end
+
+# Request / Response
+
+type Response
+    status::Int
+    message::String
+    headers::Headers
+    data::String
+    finished::Bool
+end
+
+Response(s::Int, m::String, h::Headers, d::String) = Response(s, m, h, d, false)
+Response(s::Int, m::String, h::Headers)            = Response(s, m, h, "", false)
+Response(s::Int, m::String, d::String)             = Response(s, m, headers(), d, false)
+Response(d::String, h::Headers)                    = Response(200, STATUS_CODES[200], h, d, false)
+Response(s::Int, m::String)                        = Response(s, m, headers(), "")
+Response(d::String)                                = Response(200, STATUS_CODES[200], d)
+Response(s::Int)                                   = Response(s, STATUS_CODES[s])
+Response()                                         = Response(200)
+
+# Default response headers
+headers() = (String => String)["Server" => "Julia/$VERSION"]
+
+# Utilities
+
+is_websocket_handshake( req ) = get( req.headers, "Upgrade", false ) == "websock"
+
+function event( event::String, server::Server, args... )
+    has( server.http.events, event ) ? server.http.events[event]( args... ) : false
+end
+
+# Meat / Potatoes
+
+function parse_request( client::Client )
+    RequestParser.parse_http_request( takebuf_string( client.sock.buffer ) )
+end
+
+function render( response::Response )
+    res = join(["HTTP/1.1", response.status, response.message, "\r\n"], " ")
+    for header in keys(response.headers)
+        res = string(join([ res, header, ": ", response.headers[header] ]), "\r\n")
     end
+    res = join([ res, "", response.data ], "\r\n")
+    res
+end
 
-    immutable WebsocketHandler
-        handle::Function            # ( sock ) -> ...
-    end
+# Handle client requests
 
-    # Server / Client
-
-    immutable Server
-        http::HttpHandler
-        websock::Union(Nothing,WebsocketHandler)
-    end
-
-    Server(http::HttpHandler)                        = Server( http, nothing )
-    Server(handler::Function)                        = Server( HttpHandler(handler) )
-    Server(websock::WebsocketHandler)                = Server( HttpHandler( req -> Response(404) ), websock )
-    Server(handler::Function, sockhandler::Function) = Server( HttpHandler(handler), WebsocketHandler(sockhandler) )
-
-    immutable Client
-        id::Int
-        sock::TcpSocket
-
-        Client(id::Int,sock::TcpSocket) = new(id, sock)
-    end
-
-    # Request / Response
-
-    type Response
-        status::Int
-        message::String
-        headers::Headers
-        data::String
-        finished::Bool
-    end
-
-    Response(s::Int, m::String, h::Headers, d::String) = Response(s, m, h, d, false)
-    Response(s::Int, m::String, h::Headers)            = Response(s, m, h, "", false)
-    Response(s::Int, m::String, d::String)             = Response(s, m, headers(), d, false)
-    Response(d::String, h::Headers)                    = Response(200, STATUS_CODES[200], h, d, false)
-    Response(s::Int, m::String)                        = Response(s, m, headers(), "")
-    Response(d::String)                                = Response(200, STATUS_CODES[200], d)
-    Response(s::Int)                                   = Response(s, STATUS_CODES[s])
-    Response()                                         = Response(200)
-
-    # Default response headers
-    headers() = (String => String)["Server" => "Julia/$VERSION"]
-
-    # Utilities
-
-    is_websocket_handshake( req ) = get( req.headers, "Upgrade", false ) == "websock"
-
-    event( event::String, server::Server, args... ) =
-        has( server.http.events, event ) ? server.http.events[event]( args... ) : false
-
-    # Meat / Potatoes
-
-    function parse_request( client::Client )
-        RequestParser.parse_http_request( takebuf_string( client.sock.buffer ) )
-    end
-
-    function render( response::Response )
-        res = join(["HTTP/1.1", response.status, response.message, "\r\n"], " ")
-        for header in keys(response.headers)
-            res = string(join([ res, header, ": ", response.headers[header] ]), "\r\n")
+function process_client( server::Server, client::Client, websockets_enabled::Bool )
+    event( "connect", server, client )
+    client.sock.readcb = function ( args... )                # When reading from the buffer
+        req = parse_request( client )                         # Get the data
+        println(req)
+        event( "read", server, client, req )
+        if websockets_enabled && is_websocket_handshake( req )
+            server.websock.handle( client )                  # Defer to websockets
+            return true                                      # Keep-alive
         end
-        res = join([ res, "", response.data ], "\r\n")
-        res
-    end
-
-    # Handle client requests
-
-    function process_client( server::Server, client::Client, websockets_enabled::Bool )
-        event( "connect", server, client )
-        client.sock.readcb = function ( args... )                # When reading from the buffer
-            req = parse_request( client )                         # Get the data
-            println(req)
-            event( "read", server, client, req )
-            if websockets_enabled && is_websocket_handshake( req )
-                server.websock.handle( client )                  # Defer to websockets
-                return true                                      # Keep-alive
+        local response                                       # Init response
+        try
+            response = server.http.handle( req, Response() ) # Run the server handler
+            if !isa(response, Response)                      # Promote return to Response
+                response = Response(response)
             end
-            local response                                       # Init response
-            try
-                response = server.http.handle( req, Response() ) # Run the server handler
-                if !isa(response, Response)                      # Promote return to Response
-                    response = Response(response)
-                end
             # TODO: This is going to be hard to debug -- can we get the stack trace here?
-            catch err
-                rethrow(err)
-                event( "error", server, client, err )            # Something went wrong
-                response = Response(500)                         # Throw a 500 error
-            end
-            event( "write", server, client, response )
-            write( client.sock, render(response) )               # Send the response
-            event( "close", server, client )
-            close( client.sock )                                 # Close this connection
-            false                                                # Return false to prevent an error at stream.jl:190
+        catch err
+            rethrow(err)
+            event( "error", server, client, err )            # Something went wrong
+            response = Response(500)                         # Throw a 500 error
         end
-        start_reading( client.sock )  # Start buffering request data ( when available )
+        event( "write", server, client, response )
+        write( client.sock, render(response) )               # Send the response
+        event( "close", server, client )
+        close( client.sock )                                 # Close this connection
+        false                                                # Return false to prevent an error at stream.jl:190
     end
+    start_reading( client.sock )  # Start buffering request data ( when available )
+end
 
-    # Listen on $port, accept client connections
+# Listen on $port, accept client connections
 
-    function run( server::Server, port::Integer )
-        idPool = 0                                               # Increments for each connection
-        sock = server.http.sock
-        websockets_enabled = server.websock != nothing
-        uv_error("listen", !bind(sock, Base.IPv4(uint32(0)), uint16(port)) )
-        listen( sock )
-        event( "listen", server, port )
-        while true # handle requests, Base.wait_accept blocks until a connection is made
-            client = Client( idPool += 1, Base.wait_accept( sock ) )
-            process_client( server, client, websockets_enabled )
-        end
+function run( server::Server, port::Integer )
+    idPool = 0                                               # Increments for each connection
+    sock = server.http.sock
+    websockets_enabled = server.websock != nothing
+    uv_error("listen", !bind(sock, Base.IPv4(uint32(0)), uint16(port)) )
+    listen( sock )
+    event( "listen", server, port )
+    while true # handle requests, Base.wait_accept blocks until a connection is made
+        client = Client( idPool += 1, Base.wait_accept( sock ) )
+        process_client( server, client, websockets_enabled )
     end
+end
 
 end

--- a/RequestParser.jl
+++ b/RequestParser.jl
@@ -1,121 +1,121 @@
 module RequestParser
 
-    using HttpParser
-    export RequestParser, Request, Headers
+using HttpParser
+export RequestParser, Request, Headers
 
-    typealias Headers Dict{String,String}
+typealias Headers Dict{String,String}
 
-    immutable Request
-        method::String
-        resource::String
-        headers::Headers
-        data::String
-        raw::String
-        state::Dict
+immutable Request
+    method::String
+    resource::String
+    headers::Headers
+    data::String
+    raw::String
+    state::Dict
+end
+
+type PartialRequest
+    method::Any
+    resource::String
+    headers::Headers
+    data::String
+end
+
+function reset(r::PartialRequest)
+    r.method = ""
+    r.resource = ""
+    r.headers = Dict{String, String}()
+    r.data = ""
+    r
+end
+
+r = PartialRequest("","",Dict{String, String}(),"")
+
+function on_message_begin(parser)
+    r.resource = ""
+    return 0
+end
+
+function on_url(parser, at, len)
+    r.resource = string(r.resource, bytestring(convert(Ptr{Uint8}, at),int(len)))
+    return 0
+end
+
+function on_status_complete(parser)
+    return 0
+end
+
+# Gather the header_field, set the field
+# on header value, set the value for the current field
+# there might be a better way than this: https://github.com/joyent/node/blob/master/src/node_http_parser.cc#L207
+
+function on_header_field(parser, at, len)
+    header = bytestring(convert(Ptr{Uint8}, at))
+    header_field = header[1:len]
+    # set the current header
+    r.headers["current_header"] = header_field
+    return 0
+end
+function on_header_value(parser, at, len)
+    s = bytestring(convert(Ptr{Uint8}, at),int(len))
+    # once we know we have the header value, that will be the value for current header
+    r.headers[r.headers["current_header"]] = s
+    # reset current_header
+    r.headers["current_header"] = ""
+    return 0
+end
+function on_headers_complete(parser)
+    p = unsafe_ref(parser)
+    # get first two bits of p.type_and_flags
+    println("Type and flags: ", p.type_and_flags)
+    println("Errno and upgrade: ", p.errno_and_upgrade)
+    ptype = p.type_and_flags & 0x03
+    if ptype == 0
+        r.method = http_method_str(convert(Int, p.method))
     end
-
-    type PartialRequest
-        method::Any
-        resource::String
-        headers::Headers
-        data::String
+    if ptype == 1
+        r.headers["status_code"] = string(convert(Int, p.status_code))
     end
+    r.headers["http_major"] = string(convert(Int, p.http_major))
+    r.headers["http_minor"] = string(convert(Int, p.http_minor))
+    r.headers["Keep-Alive"] = string(http_should_keep_alive(parser))
+    return 0
+end
+function on_body(parser, at, len)
+    r.data = string(r.data, bytestring(convert(Ptr{Uint8}, at)))
+    return 0
+end
+function on_message_complete(parser)
+    return 0
+end
 
-    function reset(r::PartialRequest)
-        r.method = ""
-        r.resource = ""
-        r.headers = Dict{String, String}()
-        r.data = ""
-        r
-    end
+c_message_begin_cb = cfunction(on_message_begin, Int, (Ptr{Parser},))
+c_url_cb = cfunction(on_url, Int, (Ptr{Parser}, Ptr{Cchar}, Csize_t,))
+c_status_complete_cb = cfunction(on_status_complete, Int, (Ptr{Parser},))
+c_header_field_cb = cfunction(on_header_field, Int, (Ptr{Parser}, Ptr{Cchar}, Csize_t,))
+c_header_value_cb = cfunction(on_header_value, Int, (Ptr{Parser}, Ptr{Cchar}, Csize_t,))
+c_headers_complete_cb = cfunction(on_headers_complete, Int, (Ptr{Parser},))
+c_body_cb = cfunction(on_body, Int, (Ptr{Parser}, Ptr{Cchar}, Csize_t,))
+c_message_complete_cb = cfunction(on_message_complete, Int, (Ptr{Parser},))
 
-    r = PartialRequest("","",Dict{String, String}(),"")
+function parse_http_request(http_request::String)
+    parser = Parser()
+    http_parser_init(parser)
+    settings = ParserSettings(c_message_begin_cb, c_url_cb, c_status_complete_cb, c_header_field_cb, c_header_value_cb, c_headers_complete_cb, c_body_cb, c_message_complete_cb)
 
-    function on_message_begin(parser)
-        r.resource = ""
-        return 0     
-    end     
+    http_parser_execute( parser, settings, http_request )
 
-    function on_url(parser, at, len)
-        r.resource = string(r.resource, bytestring(convert(Ptr{Uint8}, at),int(len)))
-        return 0
-    end
+    # lines = split(http_request, "\r\n")
 
-    function on_status_complete(parser)
-        return 0
-    end
+    # for i=1:length(lines)
+    #     size = http_parser_execute(parser, settings, string(lines[i],"\r\n"))
+    # end
+    # size = http_parser_execute(parser, settings, "\r\n")
 
-    # Gather the header_field, set the field
-    # on header value, set the value for the current field
-    # there might be a better way than this: https://github.com/joyent/node/blob/master/src/node_http_parser.cc#L207
-
-    function on_header_field(parser, at, len)
-        header = bytestring(convert(Ptr{Uint8}, at))
-        header_field = header[1:len]
-        # set the current header
-        r.headers["current_header"] = header_field
-        return 0
-    end
-    function on_header_value(parser, at, len)
-        s = bytestring(convert(Ptr{Uint8}, at),int(len))
-        # once we know we have the header value, that will be the value for current header
-        r.headers[r.headers["current_header"]] = s
-        # reset current_header
-        r.headers["current_header"] = ""
-        return 0
-    end
-    function on_headers_complete(parser)
-        p = unsafe_ref(parser)
-        # get first two bits of p.type_and_flags
-        println("Type and flags: ", p.type_and_flags)
-        println("Errno and upgrade: ", p.errno_and_upgrade)
-        ptype = p.type_and_flags & 0x03
-        if ptype == 0
-            r.method = http_method_str(convert(Int, p.method))
-        end
-        if ptype == 1
-            r.headers["status_code"] = string(convert(Int, p.status_code))
-        end
-        r.headers["http_major"] = string(convert(Int, p.http_major))
-        r.headers["http_minor"] = string(convert(Int, p.http_minor))
-        r.headers["Keep-Alive"] = string(http_should_keep_alive(parser))
-        return 0
-    end
-    function on_body(parser, at, len)
-        r.data = string(r.data, bytestring(convert(Ptr{Uint8}, at)))
-        return 0
-    end
-    function on_message_complete(parser)
-        return 0
-    end
-
-    c_message_begin_cb = cfunction(on_message_begin, Int, (Ptr{Parser},))
-    c_url_cb = cfunction(on_url, Int, (Ptr{Parser}, Ptr{Cchar}, Csize_t,))
-    c_status_complete_cb = cfunction(on_status_complete, Int, (Ptr{Parser},))
-    c_header_field_cb = cfunction(on_header_field, Int, (Ptr{Parser}, Ptr{Cchar}, Csize_t,))
-    c_header_value_cb = cfunction(on_header_value, Int, (Ptr{Parser}, Ptr{Cchar}, Csize_t,))
-    c_headers_complete_cb = cfunction(on_headers_complete, Int, (Ptr{Parser},))
-    c_body_cb = cfunction(on_body, Int, (Ptr{Parser}, Ptr{Cchar}, Csize_t,))
-    c_message_complete_cb = cfunction(on_message_complete, Int, (Ptr{Parser},))
-
-    function parse_http_request(http_request::String)
-        parser = Parser()
-        http_parser_init(parser)
-        settings = ParserSettings(c_message_begin_cb, c_url_cb, c_status_complete_cb, c_header_field_cb, c_header_value_cb, c_headers_complete_cb, c_body_cb, c_message_complete_cb)
-
-        http_parser_execute( parser, settings, http_request )
-
-        # lines = split(http_request, "\r\n")
-
-        # for i=1:length(lines)
-        #     size = http_parser_execute(parser, settings, string(lines[i],"\r\n"))
-        # end
-        # size = http_parser_execute(parser, settings, "\r\n")
-
-        delete!(r.headers,"current_header",nothing)
-        req = Request(r.method,r.resource,r.headers,r.data,http_request,Dict())
-        reset(r)
-        req
-    end
+    delete!(r.headers,"current_header",nothing)
+    req = Request(r.method,r.resource,r.headers,r.data,http_request,Dict())
+    reset(r)
+    req
+end
 
 end

--- a/RequestParser.jl
+++ b/RequestParser.jl
@@ -1,18 +1,12 @@
 module RequestParser
 
 using HttpParser
-export RequestParser, Request, Headers
+export RequestParser, Request, Headers, clean!, add_data
+
+HTTP_CB      = (Int, (Ptr{Parser},))
+HTTP_DATA_CB = (Int, (Ptr{Parser}, Ptr{Cchar}, Csize_t,))
 
 typealias Headers Dict{String,String}
-
-immutable Request
-    method::String
-    resource::String
-    headers::Headers
-    data::String
-    raw::String
-    state::Dict
-end
 
 type PartialRequest
     method::Any
@@ -20,51 +14,69 @@ type PartialRequest
     headers::Headers
     data::String
 end
+PartialRequest() = PartialRequest("", "", Dict{String, String}(), "")
 
-function reset(r::PartialRequest)
-    r.method = ""
-    r.resource = ""
-    r.headers = Dict{String, String}()
-    r.data = ""
-    r
+# IMPORTANT!!! This requires manual memory management.
+#
+# Each Client needs its own PartialRequest. Since closures are not
+# c-callable, we have to keep a global dictionary of Parser pointers
+# to PartialRequests. Callbacks will lookup their partial in this
+# global dict. Partials must be manually deleted when connections
+# are closed or memory leaks will occur.
+partials = Dict{Ptr{Parser}, PartialRequest}()
+message_complete_callbacks = Dict{Ptr, Function}()
+
+immutable Request
+    method::String
+    resource::String
+    headers::Headers
+    data::String
+    state::Dict
 end
-
-r = PartialRequest("","",Dict{String, String}(),"")
+Request(r::PartialRequest) = Request(r.method, r.resource, r.headers, r.data, Dict())
 
 function on_message_begin(parser)
-    r.resource = ""
+    r = partials[parser] = PartialRequest()
     return 0
 end
+on_message_begin_cb = cfunction(on_message_begin, HTTP_CB...)
 
 function on_url(parser, at, len)
+    r = partials[parser]
     r.resource = string(r.resource, bytestring(convert(Ptr{Uint8}, at),int(len)))
     return 0
 end
+on_url_cb = cfunction(on_url, HTTP_DATA_CB...)
 
 function on_status_complete(parser)
     return 0
 end
+on_status_complete_cb = cfunction(on_status_complete, HTTP_CB...)
 
 # Gather the header_field, set the field
 # on header value, set the value for the current field
 # there might be a better way than this: https://github.com/joyent/node/blob/master/src/node_http_parser.cc#L207
 
 function on_header_field(parser, at, len)
+    r = partials[parser]
     header = bytestring(convert(Ptr{Uint8}, at))
     header_field = header[1:len]
-    # set the current header
     r.headers["current_header"] = header_field
     return 0
 end
+on_header_field_cb = cfunction(on_header_field, HTTP_DATA_CB...)
+
 function on_header_value(parser, at, len)
+    r = partials[parser]
     s = bytestring(convert(Ptr{Uint8}, at),int(len))
-    # once we know we have the header value, that will be the value for current header
     r.headers[r.headers["current_header"]] = s
-    # reset current_header
     r.headers["current_header"] = ""
     return 0
 end
+on_header_value_cb = cfunction(on_header_value, HTTP_DATA_CB...)
+
 function on_headers_complete(parser)
+    r = partials[parser]
     p = unsafe_ref(parser)
     # get first two bits of p.type_and_flags
     println("Type and flags: ", p.type_and_flags)
@@ -72,8 +84,7 @@ function on_headers_complete(parser)
     ptype = p.type_and_flags & 0x03
     if ptype == 0
         r.method = http_method_str(convert(Int, p.method))
-    end
-    if ptype == 1
+    elseif ptype == 1
         r.headers["status_code"] = string(convert(Int, p.status_code))
     end
     r.headers["http_major"] = string(convert(Int, p.http_major))
@@ -81,41 +92,51 @@ function on_headers_complete(parser)
     r.headers["Keep-Alive"] = string(http_should_keep_alive(parser))
     return 0
 end
+on_headers_complete_cb = cfunction(on_headers_complete, HTTP_CB...)
+
 function on_body(parser, at, len)
+    r = partials[parser]
     r.data = string(r.data, bytestring(convert(Ptr{Uint8}, at)))
     return 0
 end
+on_body_cb = cfunction(on_body, HTTP_DATA_CB...)
+
 function on_message_complete(parser)
+    r = partials[parser]
+    delete!(r.headers, "current_header", nothing)
+    req = Request(r)
+
+    message_complete_callbacks[unsafe_ref(parser).data](req)
+
     return 0
 end
+on_message_complete_cb = cfunction(on_message_complete, HTTP_CB...)
 
-c_message_begin_cb = cfunction(on_message_begin, Int, (Ptr{Parser},))
-c_url_cb = cfunction(on_url, Int, (Ptr{Parser}, Ptr{Cchar}, Csize_t,))
-c_status_complete_cb = cfunction(on_status_complete, Int, (Ptr{Parser},))
-c_header_field_cb = cfunction(on_header_field, Int, (Ptr{Parser}, Ptr{Cchar}, Csize_t,))
-c_header_value_cb = cfunction(on_header_value, Int, (Ptr{Parser}, Ptr{Cchar}, Csize_t,))
-c_headers_complete_cb = cfunction(on_headers_complete, Int, (Ptr{Parser},))
-c_body_cb = cfunction(on_body, Int, (Ptr{Parser}, Ptr{Cchar}, Csize_t,))
-c_message_complete_cb = cfunction(on_message_complete, Int, (Ptr{Parser},))
+immutable ClientParser
+    parser::Parser
+    settings::ParserSettings
 
-function parse_http_request(http_request::String)
-    parser = Parser()
-    http_parser_init(parser)
-    settings = ParserSettings(c_message_begin_cb, c_url_cb, c_status_complete_cb, c_header_field_cb, c_header_value_cb, c_headers_complete_cb, c_body_cb, c_message_complete_cb)
+    function ClientParser(on_message_complete::Function)
+        parser = Parser()
+        http_parser_init(parser)
+        message_complete_callbacks[parser.data] = on_message_complete
 
-    http_parser_execute( parser, settings, http_request )
+        settings = ParserSettings(on_message_begin_cb, on_url_cb,
+                                  on_status_complete_cb, on_header_field_cb,
+                                  on_header_value_cb, on_headers_complete_cb,
+                                  on_body_cb, on_message_complete_cb)
 
-    # lines = split(http_request, "\r\n")
+        new(parser, settings)
+    end
+end
 
-    # for i=1:length(lines)
-    #     size = http_parser_execute(parser, settings, string(lines[i],"\r\n"))
-    # end
-    # size = http_parser_execute(parser, settings, "\r\n")
+function add_data(parser::ClientParser, request_data::String)
+    http_parser_execute( parser.parser, parser.settings, request_data )
+end
 
-    delete!(r.headers,"current_header",nothing)
-    req = Request(r.method,r.resource,r.headers,r.data,http_request,Dict())
-    reset(r)
-    req
+function clean!(parser::ClientParser)
+    delete!(partials, parser.parser, nothing)
+    delete!(message_complete_callbacks, parser.parser.data, nothing)
 end
 
 end


### PR DESCRIPTION
Concurrency was totally broken in the previous version. Each callback
relied on a global PartialRequest that would be clobbered randomly by
concurrent parsers.

Unfortunately, there's not a super clean way of solving this problem
because closures are not c-callable yet. We get around this by using
global dictionaries of parsers => partials and parsers => on_complete
callbacks.

One major bummer: this requires manual garbage collection and right now
we'll leak memory for hung connections.
