### PR TITLE
Don't merge: Circular Dependency issue

### DIFF
--- a/Http/src/Http.jl
+++ b/Http/src/Http.jl
@@ -1,5 +1,6 @@
 module Http
 
+using Websockets
 include("RequestParser.jl")
 export Server, 
        HttpHandler, 
@@ -167,7 +168,9 @@ function message_handler(server::Server, client::Client, websockets_enabled::Boo
     # After parsing is done, the HttpHandler & WebsockHandler are passed the Request
     function on_message_complete(req::Request)
             if websockets_enabled && is_websocket_handshake(req)
-                server.websock.handle(req, client)             # Defer to websockets
+                websocket_handshake(req,client)
+                ws = WebSocket(client.id,client.sock)
+                server.websock.handle(req, ws)                 # Defer to websockets
                 return true                                    # Keep-alive
             end
 

--- a/Websockets/src/Websockets.jl
+++ b/Websockets/src/Websockets.jl
@@ -224,9 +224,4 @@ websocket_handshake(request,client) = begin
   Base.write(client.sock,"$response$resp_key\r\n\r\n")
 end
 
-websocket_handler(handler) = (request,client) -> begin
-  websocket_handshake(request,client)
-  handler(request,WebSocket(client.id,client.sock))
-end
-
 end # module Websockets

--- a/examples/chat.jl
+++ b/examples/chat.jl
@@ -4,7 +4,7 @@ using Websockets
 #global Dict to store open connections in
 @show global connections = {0 => WebSocket(0,TcpSocket())}
 
-wsh = websocket_handler((req,client) -> begin
+wsh = WebsocketHandler() do req::Request,client::WebSocket
   global connections
   @show connections[client.id] = client 
   while true
@@ -15,14 +15,12 @@ wsh = websocket_handler((req,client) -> begin
       end
     end
   end
-end)
-
-wshh = WebsocketHandler(wsh)
+end
 
 onepage = readall("./examples/chat-client.html")
 httph = HttpHandler() do req::Request, res::Response
   Response(onepage)
 end
 
-server = Server(httph,wshh)
+server = Server(httph,wsh)
 run(server,8080)

--- a/examples/websockets.jl
+++ b/examples/websockets.jl
@@ -1,12 +1,11 @@
 using Http
 using Websockets
 
-wsh = websocket_handler((req,client) -> begin
+wsh = WebsocketHandler() do req::Request,client::WebSocket
 	while true
 		msg = read(client)
 		write(client, msg)
 	end
-end)
-wshh = WebsocketHandler(wsh)
-server = Server(wshh)
+end
+server = Server(wsh)
 run(server,8080)


### PR DESCRIPTION
I want the websockets example/user code to not have to explicitly call the websockets handshake function.
This means that the Http server would call it before calling the application's websocket handler.
Websockets uses the Http Request type, in order to do the Handshake.
This creates a circular dependency.

Solution Options:
1) Websockets and Http should be one thing, so they can full depend on each other
2) Websockets should not depend on Http Request: just have Http hand it the required headers.
3) Http should not depend on Websockets... some way of making the websocket constructors/handler do this automatically....

Any opinions on how to solve this?
