### PR TITLE
RFC: Redefines WebsocketHandler to wrap with handshake

### DIFF
--- a/Http/src/Http.jl
+++ b/Http/src/Http.jl
@@ -3,7 +3,7 @@ module Http
 include("RequestParser.jl")
 export Server, 
        HttpHandler, 
-       WebsocketHandler, 
+       WebsocketClientHandler, 
        Request, 
        Response, 
        run
@@ -78,7 +78,7 @@ immutable HttpHandler
     HttpHandler(handle::Function) = new(handle, TcpSocket(), (ASCIIString=>Function)[])
 end
 
-immutable WebsocketHandler
+immutable WebsocketClientHandler
     handle::Function # (request, sock) -> ...
 end
 
@@ -87,12 +87,12 @@ end
 
 immutable Server
     http::HttpHandler
-    websock::Union(Nothing,WebsocketHandler)
+    websock::Union(Nothing,WebsocketClientHandler)
 end
 Server(http::HttpHandler)                        = Server(http, nothing)
 Server(handler::Function)                        = Server(HttpHandler(handler))
-Server(websock::WebsocketHandler)                = Server(HttpHandler((req, res) -> Response(404)), websock)
-Server(handler::Function, sockhandler::Function) = Server(HttpHandler(handler), WebsocketHandler(sockhandler))
+Server(websock::WebsocketClientHandler)                = Server(HttpHandler((req, res) -> Response(404)), websock)
+Server(handler::Function, sockhandler::Function) = Server(HttpHandler(handler), WebsocketClientHandler(sockhandler))
 
 type Client
     id::Int

--- a/Websockets/src/Websockets.jl
+++ b/Websockets/src/Websockets.jl
@@ -5,7 +5,7 @@ export WebSocket,
        write,
        read,
        close,
-       websocket_handler
+       WebsocketHandler
 
 type WebSocket
   id::Int
@@ -224,9 +224,9 @@ websocket_handshake(request,client) = begin
   Base.write(client.sock,"$response$resp_key\r\n\r\n")
 end
 
-websocket_handler(handler) = (request,client) -> begin
+WebsocketHandler(handler) = WebsocketClientHandler((request,client) -> begin
   websocket_handshake(request,client)
   handler(request,WebSocket(client.id,client.sock))
-end
+end)
 
 end # module Websockets

--- a/examples/chat.jl
+++ b/examples/chat.jl
@@ -4,7 +4,7 @@ using Websockets
 #global Dict to store open connections in
 @show global connections = {0 => WebSocket(0,TcpSocket())}
 
-wsh = websocket_handler((req,client) -> begin
+wsh = WebsocketHandler() do req,client
   global connections
   @show connections[client.id] = client 
   while true
@@ -15,14 +15,12 @@ wsh = websocket_handler((req,client) -> begin
       end
     end
   end
-end)
-
-wshh = WebsocketHandler(wsh)
+end
 
 onepage = readall("./examples/chat-client.html")
 httph = HttpHandler() do req::Request, res::Response
   Response(onepage)
 end
 
-server = Server(httph,wshh)
+server = Server(httph,wsh)
 run(server,8080)

--- a/examples/websockets.jl
+++ b/examples/websockets.jl
@@ -1,12 +1,12 @@
 using Http
 using Websockets
 
-wsh = websocket_handler((req,client) -> begin
+wsh = WebsocketHandler() do req, client
 	while true
 		msg = read(client)
 		write(client, msg)
 	end
-end)
-wshh = WebsocketHandler(wsh)
-server = Server(wshh)
+end
+
+server = Server(wsh)
 run(server,8080)


### PR DESCRIPTION
- Renames WebsocketHandler to WebsocketClientHandler under the hood.
- Redefines WebsocketHandler to wrap a WebsocketClientHandler in
  the handshake method.
- Preserves existing API of WebsocketHandler and HttpHandler constructors.

This is an alternative to #38
