### PR TITLE
Micro dynamic routing

### DIFF
--- a/Micro/src/Micro.jl
+++ b/Micro/src/Micro.jl
@@ -14,6 +14,7 @@ export App,
        delete,
        start,
        url_params,
+       route_params,
 
        # from Httplib
        GET,
@@ -71,6 +72,8 @@ function route(handler::Function, app::App, methods::Int, path::String)
 end
 route(a::App, m::Int, p::String, h::Function) = route(h, a, m, p)
 
+import Base.get
+
 # These are shortcut functions for common calls to `route`.
 # e.g `get` calls `route` with a `GET` as the method parameter.
 #
@@ -80,9 +83,16 @@ put(h::Function, a::App, p::String)    = route(h, a, PUT, p)
 update(h::Function, a::App, p::String) = route(h, a, UPDATE, p)
 delete(h::Function, a::App, p::String) = route(h, a, DELETE, p)
 
+# Convenience methods for getting url parameters from req.state[:url_params]
+#
 url_params(req::Request)                       = req.state[:url_params]
 url_params(req::Request, key::String, default) = get(req.state[:url_params], key, default)
 url_params(req::Request, key::String)          = url_params(req, key, nothing)
+
+# Convenience methods for getting route parameters from req.state[:route_params]
+#
+route_params(req::Request)                     = get(req.state, :route_params, nothing)
+route_params(req::Request, key::Symbol)        = has(req.state, :route_params) ? get(req.state[:route_params], key, nothing) : nothing
 
 # `prepare_response` simply sets the data field of the `Response` to the input
 # string `s` and calls the middleware's `repsond` function.
@@ -102,7 +112,8 @@ function start(app::App, port::Int)
 
     MicroApp = Midware() do req::Request, res::Response
         path = vcat(["/"], split(rstrip(req.resource,"/"),"/")[2:end])
-        handler = match_route_handler(app.routes[HttpMethodNameToBitmask[req.method]], path)
+        routeTable = app.routes[HttpMethodNameToBitmask[req.method]]
+        handler, req.state[:route_params] = match_route_handler(routeTable, path)
         if handler != nothing
            return prepare_response(handler(req, res), req, res)
         end

--- a/Micro/src/Micro.jl
+++ b/Micro/src/Micro.jl
@@ -112,8 +112,8 @@ function start(app::App, port::Int)
 
     MicroApp = Midware() do req::Request, res::Response
         path = vcat(["/"], split(rstrip(req.resource,"/"),"/")[2:end])
-        routeTable = app.routes[HttpMethodNameToBitmask[req.method]]
-        handler, req.state[:route_params] = match_route_handler(routeTable, path)
+        methodizedRouteTable = app.routes[HttpMethodNameToBitmask[req.method]]
+        handler, req.state[:route_params] = match_route_handler(methodizedRouteTable, path)
         if handler != nothing
            return prepare_response(handler(req, res), req, res)
         end

--- a/Micro/src/Routes.jl
+++ b/Micro/src/Routes.jl
@@ -3,17 +3,42 @@ include("Trees.jl")
 typealias Params Dict{Any,Any}
 
 abstract RouteNode
-getparams(params::Params, v::RouteNode, p::String) = params
 
+# StringNodes store all static route parts
+# For example, route "/foo/bar/" is comprised of 2 StringNodes, "foo" and "bar"
+#
 immutable StringNode <: RouteNode
     val::String
 end
+# Equality & Matching for building / traversing the routing table
 isequal(s1::StringNode, s2::String)     = s1.val == s2
 isequal(s1::StringNode, s2::StringNode) = s1.val == s2.val
 ismatch(s1::StringNode, s2::String)     = isequal(s1, s2)
 
+# Returns the name part of a RegEx or DataType dynamic route
+# Will return `foo` in `<foo::String>`
+#
 getname(p::String) = Base.ismatch(r"^<([^\:]*)::", p) ? match(r"^<([^\:]*)::", p).captures[1] : nothing
 
+# DynamicNodes
+#
+# Route search uses `regex` to validate matches,
+# then adds key `name` to `req.state[:params]` with unique value from
+# resource after it is ( optionally ) processed through `convert`.
+#
+# DynamicNodes are used for three kinds of nodes:
+#
+#   - NamedParamNodes:     "/foo/<bar>" 
+#            => matches    "/foo/*", adds `req.params[:bar]::String`
+#
+#   - RegexNodes:          "/foo/<bar::%[0-9][0-9]-[A-Z]{5}>"
+#            => matches    "/foo/00-ABCDE", adds `req.params[:bar]::String`
+#            => wont match "/foo/00-ABCDEF", "foo/0-ABCDE"
+#
+#   - DataTypeNodes:       "/foo/<bar::Int>"
+#            => matches    "/foo/10", adds `req.params[:bar]::Int`
+#            => wont match "/foo/10.0", "foo/abc"
+#
 immutable DynamicNode <: RouteNode
     name::String
     regex::Regex
@@ -22,18 +47,29 @@ end
 DynamicNode(n::String, r::Regex)    = DynamicNode(n,r,nothing)
 DynamicNode(p::String, c::Function) = DynamicNode(getname(p), Regex("^$(match(r":%([^>]*)>", p).captures[1])\$"), c)
 
-RegexNode(p::String) = DynamicNode(getname(p), Regex("^$(match(r":%([^>]*)>", p).captures[1])\$"))
-NamedParamNode(p::String) = DynamicNode(p[2:length(p)-1], r".*")
-const DataTypeNodeBuilders = (String => (Regex, Function))[ 
-    "Int"   => (r"^[0-9]*$", int),
-    "Float" => (r"^[0-9]*\.[0-9]*", float)
-]
-DataTypeNode(p::String, t::String) = DynamicNode(getname(p), DataTypeNodeBuilders[t]...)
-
+# Equality & Matching for building / traversing the routing table
 isequal(s1::DynamicNode, s2::String)      = Base.ismatch( s1.regex, s2 )
 isequal(s1::DynamicNode, s2::DynamicNode) = s1.regex.pattern == s2.regex.pattern && s1.name == s2.name
 ismatch(s1::DynamicNode, s2::String)      = isequal( s1, s2 )
-getparams(params::Params, v::DynamicNode, p::String) = params[symbol(v.name)] = v.convert == nothing ? p : v.convert(p)
+
+# NamedParam & Regex node constructors, these are NOT types.
+NamedParamNode(p::String) = DynamicNode(p[2:length(p)-1], r".*")
+RegexNode(p::String)      = DynamicNode(getname(p), Regex("^$(match(r":%([^>]*)>", p).captures[1])\$"))
+
+# All valid DataTypeNode types -- provides `regex` validator + converter.
+# Should be exposed to users for extension with custom DataTypes?
+#
+const DataTypeNodeBuilders = (String => (Regex, Function))[ 
+    "Int"   => (r"^[0-9]*$", int),
+    "Float" => (r"^[0-9]*\.[0-9]*$", float),
+    "String"=> (r"^.*$", string)
+]
+# DataType node constructor, also NOT a type.
+DataTypeNode(p::String, t::String) = DynamicNode(getname(p), DataTypeNodeBuilders[t]...)
+
+# Build the params dataset – dispatch needed for both route types.
+extend_params(params::Params, v::RouteNode, p::String) = params
+extend_params(params::Params, v::DynamicNode, p::String) = params[symbol(v.name)] = v.convert == nothing ? p : v.convert(p)
 
 typealias Route (RouteNode,Union(Function,Nothing)) # ('/about', function()...)
 isequal(r::Route, v) = isequal(r[1], v)
@@ -45,12 +81,16 @@ RoutingTable() = RoutingTable((StringNode("/"), nothing))
 
 ismatch(node::String, resource_chunk::String) = node == resource_chunk
 
+# Regex matchers for determining DynamicRoute types =>
+# Functions for building matching type from `part`.
+#
 const dynamic_route_dispatch = (Regex => Function)[
     r"^<[^:%]*::%"          => RegexNode,
-    r"^<[^:>]*::([^%>]*)>$" => part -> DataTypeNode(part, match(r"^<[^:>]*::([^%>]*)>$", part).captures[1]),
+    r"^<[^:>]*::[^%>]*>$"   => part -> DataTypeNode(part, match(r"^<[^:>]*::([^%>]*)>$", part).captures[1]),
     r"^<[^:>]*>$"           => NamedParamNode
 ]
 
+# Run for each part of a route, builds RouteNodes.
 function parse_part(part::String)
     if length(part) > 0 && Base.ismatch(r"^<[^>]*>$", part) 
         for v in dynamic_route_dispatch
@@ -120,7 +160,7 @@ end
 function searchroute(parts::Array, params::Params)
     function searchpred(val)
         if ismatch(val, parts[1])
-            params = getparams(params, val[1], parts[1])
+            params = extend_params(params, val[1], parts[1])
             if length(parts) == 1
                 true
             else

--- a/examples/micro.jl
+++ b/examples/micro.jl
@@ -28,16 +28,12 @@ get(app, "/datatype/<test::Int>") do req, res
 	"Int: $(route_params(req, :test))"
 end
 
+get(app, "/datatype/<test::Float>") do req, res
+	"Float: $(route_params(req, :test))"
+end
+
 get(app, "/named/<test>") do req, res
 	"Named: $(route_params(req, :test))"
-end
-
-global boner = function( args... )
-	"Suck it."
-end
-
-get(app, "/converter/<test::boner>") do req, res
-	"Converter: $(route_params(req, :test))"
 end
 
 start(app, 8000)

--- a/examples/micro.jl
+++ b/examples/micro.jl
@@ -20,4 +20,9 @@ get(app, "/show/urlparams") do req, res
 	repr(params)
 end
 
+get(app, "/regex/<test::%[0-9][0-9]-[a-z]*>") do req, res
+	"Now you have 2 problems! test: $(route_params(req, :test))"
+end
+
+
 start(app, 8000)

--- a/examples/micro.jl
+++ b/examples/micro.jl
@@ -24,5 +24,20 @@ get(app, "/regex/<test::%[0-9][0-9]-[a-z]*>") do req, res
 	"Now you have 2 problems! test: $(route_params(req, :test))"
 end
 
+get(app, "/datatype/<test::Int>") do req, res
+	"Int: $(route_params(req, :test))"
+end
+
+get(app, "/named/<test>") do req, res
+	"Named: $(route_params(req, :test))"
+end
+
+global boner = function( args... )
+	"Suck it."
+end
+
+get(app, "/converter/<test::boner>") do req, res
+	"Converter: $(route_params(req, :test))"
+end
 
 start(app, 8000)


### PR DESCRIPTION
Adds dynamic routes to `Micro` – supports the following:

``` .jl
get(app, "/regex/<test::%[0-9][0-9]-[a-z]*>") do req, res
    "Now you have 2 problems! test: $(route_params(req, :test))"
end

get(app, "/datatype/<test::Int>") do req, res
    "Int: $(route_params(req, :test))"
end

get(app, "/datatype/<test::Float>") do req, res
    "Float: $(route_params(req, :test))"
end

get(app, "/named/<test>") do req, res
    "Named: $(route_params(req, :test))"
end
```
