### PR TITLE
Http protocol conformity

### DIFF
--- a/Http/src/Http.jl
+++ b/Http/src/Http.jl
@@ -140,7 +140,7 @@ function render(response::Response)
         res = string(join([ res, header, ": ", response.headers[header] ]), "\r\n")
     end
 
-    join([ res, "", response.data ], "\r\n")
+    res * "\r\n" * response.data
 end
 
 # `run` starts `server` listening on `port`. 
@@ -219,8 +219,8 @@ function message_handler(server::Server, client::Client, websockets_enabled::Boo
             event("error", server, client, err)             # Something went wrong
             Base.display_error(err, catch_backtrace())      # Prints backtrace without throwing
         end
-        response.data = response.data * "\r\n\r\n"
-        response.headers["Content-Length"] = string(length(response.data)+2)
+
+        response.headers["Content-Length"] = string(length(response.data))
 
         write(client.sock, render(response))                # Send the response
         event("write", server, client, response)

--- a/Http/src/Http.jl
+++ b/Http/src/Http.jl
@@ -219,6 +219,8 @@ function message_handler(server::Server, client::Client, websockets_enabled::Boo
             event("error", server, client, err)             # Something went wrong
             Base.display_error(err, catch_backtrace())      # Prints backtrace without throwing
         end
+        response.data = response.data * "\r\n\r\n"
+        response.headers["Content-Length"] = string(length(response.data)+2)
 
         write(client.sock, render(response))                # Send the response
         event("write", server, client, response)

--- a/Httplib/src/Httplib.jl
+++ b/Httplib/src/Httplib.jl
@@ -106,7 +106,7 @@ const HttpMethodBitmaskToName = (HttpMethodBitmask => String)[v => k for (k, v) 
 # Default HTTP headers
 # RFC 1123 datetime formatting constants
 DAY_NAMES = split("Sun Mon Tue Wed Thu Fri Sat")
-RFC1123_FORMAT_STR = "dd MMM yyyy hh:mm:ss"
+RFC1123_FORMAT_STR = "dd MMM yyyy HH:mm:ss"
 
 # Get RFC 1123 datetimes
 #
@@ -126,9 +126,9 @@ RFC1123_datetime() = RFC1123_datetime(now())
 #
 typealias Headers Dict{String,String}
 headers() = (String => String)[ "Server" => "Julia/$VERSION",
-                                "Content-type" => "text/html; charset=UTF-8",
-                                "Content-language" => "en",
-                                "Date" => RFC1123_datetime() ]
+                                "Content-Type" => "text/html; charset=utf-8",
+                                "Content-Language" => "en",
+                                "Date" => RFC1123_datetime()]
 
 # HTTP request
 #


### PR DESCRIPTION
Adds `Content-Length`, streamlines response rendering & fixes bug with `RFC1123` time formatter string.
